### PR TITLE
Put minSdkVersion at 3 and 11

### DIFF
--- a/nucleus-example-with-tests/build.gradle
+++ b/nucleus-example-with-tests/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "info.android15.nucleusexample"
-        minSdkVersion 15
+        minSdkVersion 11
         targetSdkVersion 21
     }
 

--- a/nucleus-example/build.gradle
+++ b/nucleus-example/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "info.android15.nucleusexample"
-        minSdkVersion 15
+        minSdkVersion 11
         targetSdkVersion 21
     }
 }

--- a/nucleus-support-tests/build.gradle
+++ b/nucleus-support-tests/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "22.0.0"
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 3
         targetSdkVersion 21
     }
 }

--- a/nucleus-support-v4/build.gradle
+++ b/nucleus-support-v4/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "22.0.0"
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 3
         targetSdkVersion 21
     }
 }

--- a/nucleus-support-v7/build.gradle
+++ b/nucleus-support-v7/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "22.0.0"
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 3
         targetSdkVersion 21
     }
 }

--- a/nucleus/build.gradle
+++ b/nucleus/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "22.0.0"
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 3
         targetSdkVersion 21
     }
 }


### PR DESCRIPTION
I couldn't find a reason the minSdkVersion was set to 15, so this PR reduces it, making the library more accessible to people using lower Android versions.

All core modules are set at 3 because of a `View.isInEditMode()` usage, and all examples modules are set at 11 due to an `ArrayAdapter.addAll()` usage.
