### PR TITLE
nucleuslayout: Try to unwrap context wrappers

### DIFF
--- a/nucleus/src/androidTest/java/nucleus/view/NucleusLayoutTestActivity.java
+++ b/nucleus/src/androidTest/java/nucleus/view/NucleusLayoutTestActivity.java
@@ -2,6 +2,7 @@ package nucleus.view;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.os.Bundle;
 import android.view.ViewGroup;
 
@@ -26,7 +27,10 @@ public class NucleusLayoutTestActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(view = new TestView(this));
+
+        // Create a dummy wrapper to guarantee that NucleusLayout properly
+        // unwraps contexts before casting them to activities
+        setContentView(view = new TestView(new ContextWrapper(this)));
     }
 
     @Override

--- a/nucleus/src/main/java/nucleus/view/NucleusLayout.java
+++ b/nucleus/src/main/java/nucleus/view/NucleusLayout.java
@@ -2,6 +2,7 @@ package nucleus.view;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.util.AttributeSet;
@@ -59,7 +60,17 @@ public abstract class NucleusLayout<PresenterType extends Presenter> extends Fra
     @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
-        helper.dropView(((Activity)getContext()).isFinishing());
+
+        Context context = getContext();
+        while (context instanceof ContextWrapper && !(context instanceof Activity)) {
+            context = ((ContextWrapper)context).getBaseContext();
+        }
+
+        if (!(context instanceof Activity)) {
+            throw new IllegalStateException("Expected an activity context, got " + context.getClass().getSimpleName());
+        }
+
+        helper.dropView(((Activity)context).isFinishing());
     }
 
     // The following section can be copy & pasted into any View class, just update their description if needed.


### PR DESCRIPTION
NucleusLayout casts the context to activity, but if for some reason
they were wrapped along the way, the cast will fail.

This patch tries to unwrap contextwrappers and aborts if the
resulting context cannot be casted to Activity.