### PR TITLE
Replace SubscriptionList with CompositeSubscription in RxPresenter

### DIFF
--- a/nucleus/src/main/java/nucleus/presenter/RxPresenter.java
+++ b/nucleus/src/main/java/nucleus/presenter/RxPresenter.java
@@ -17,8 +17,8 @@ import rx.Subscription;
 import rx.functions.Action1;
 import rx.functions.Action2;
 import rx.functions.Func0;
-import rx.internal.util.SubscriptionList;
 import rx.subjects.BehaviorSubject;
+import rx.subscriptions.CompositeSubscription;
 
 /**
  * This is an extension of {@link Presenter} which provides RxJava functionality.
@@ -30,7 +30,7 @@ public class RxPresenter<View> extends Presenter<View> {
     private static final String REQUESTED_KEY = RxPresenter.class.getName() + "#requested";
 
     private final BehaviorSubject<View> views = BehaviorSubject.create();
-    private final SubscriptionList subscriptions = new SubscriptionList();
+    private final CompositeSubscription subscriptions = new CompositeSubscription();
 
     private final HashMap<Integer, Func0<Subscription>> restartables = new HashMap<>();
     private final HashMap<Integer, Subscription> restartableSubscriptions = new HashMap<>();
@@ -48,7 +48,7 @@ public class RxPresenter<View> extends Presenter<View> {
 
     /**
      * Registers a subscription to automatically unsubscribe it during onDestroy.
-     * See {@link SubscriptionList#add(Subscription) for details.}
+     * See {@link CompositeSubscription#add(Subscription) for details.}
      *
      * @param subscription a subscription to add.
      */
@@ -58,7 +58,7 @@ public class RxPresenter<View> extends Presenter<View> {
 
     /**
      * Removes and unsubscribes a subscription that has been registered with {@link #add} previously.
-     * See {@link SubscriptionList#remove(Subscription)} for details.
+     * See {@link CompositeSubscription#remove(Subscription)} for details.
      *
      * @param subscription a subscription to remove.
      */


### PR DESCRIPTION
`SubscriptionList` is RxJava's internal type so we shouldn't use it. Note
that the APIs are nearly identical so this change doesn't require any
more work than switching the type.