### PR TITLE
New deliver

### DIFF
--- a/nucleus/src/main/java/nucleus/presenter/RxPresenter.java
+++ b/nucleus/src/main/java/nucleus/presenter/RxPresenter.java
@@ -3,6 +3,11 @@ package nucleus.presenter;
 import android.os.Bundle;
 import android.support.annotation.CallSuper;
 import android.support.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
 import nucleus.presenter.delivery.DeliverFirst;
 import nucleus.presenter.delivery.DeliverLatest;
 import nucleus.presenter.delivery.DeliverLatestCache;
@@ -15,10 +20,6 @@ import rx.functions.Action2;
 import rx.functions.Func0;
 import rx.subjects.BehaviorSubject;
 import rx.subscriptions.CompositeSubscription;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * This is an extension of {@link Presenter} which provides RxJava functionality.

--- a/nucleus/src/main/java/nucleus/presenter/RxPresenter.java
+++ b/nucleus/src/main/java/nucleus/presenter/RxPresenter.java
@@ -3,12 +3,8 @@ package nucleus.presenter;
 import android.os.Bundle;
 import android.support.annotation.CallSuper;
 import android.support.annotation.Nullable;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-
 import nucleus.presenter.delivery.DeliverFirst;
+import nucleus.presenter.delivery.DeliverLatest;
 import nucleus.presenter.delivery.DeliverLatestCache;
 import nucleus.presenter.delivery.DeliverReplay;
 import nucleus.presenter.delivery.Delivery;
@@ -19,6 +15,10 @@ import rx.functions.Action2;
 import rx.functions.Func0;
 import rx.subjects.BehaviorSubject;
 import rx.subscriptions.CompositeSubscription;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This is an extension of {@link Presenter} which provides RxJava functionality.
@@ -223,6 +223,18 @@ public class RxPresenter<View> extends Presenter<View> {
      */
     public <T> DeliverLatestCache<View, T> deliverLatestCache() {
         return new DeliverLatestCache<>(views);
+    }
+
+    /**
+     * Returns an {@link rx.Observable.Transformer} that couples views with data that has been emitted by
+     * the source {@link rx.Observable}.
+     *
+     * {@link #deliverLatest} delivers each onNext value that has been emitted by the source observable until the the source observable is completed.
+     *
+     * @param <T> the type of source observable emissions
+     */
+    public <T> DeliverLatest<View, T> deliverLatest() {
+        return new DeliverLatest<>(views);
     }
 
     /**

--- a/nucleus/src/main/java/nucleus/presenter/delivery/DeliverLatest.java
+++ b/nucleus/src/main/java/nucleus/presenter/delivery/DeliverLatest.java
@@ -1,0 +1,62 @@
+package nucleus.presenter.delivery;
+
+import rx.Notification;
+import rx.Observable;
+import rx.Subscriber;
+import rx.Subscription;
+import rx.functions.Action0;
+import rx.functions.Func1;
+import rx.functions.Func2;
+
+public class DeliverLatest<View, T> implements Observable.Transformer<T, Delivery<View, T>> {
+
+    private final Observable<View> view;
+
+    public DeliverLatest(Observable<View> view) {
+        this.view = view;
+    }
+
+    @Override
+    public Observable<Delivery<View, T>> call(final Observable<T> observable) {
+        return Observable.create(new Observable.OnSubscribe<Delivery<View, T>>() {
+            @Override
+            public void call(final Subscriber<? super Delivery<View, T>> subscriber) {
+                Subscription subscription = Observable
+                        .combineLatest(
+                                view,
+                                observable
+                                        .doOnCompleted(new Action0() {
+                                            @Override
+                                            public void call() {
+                                                if (!subscriber.isUnsubscribed()) {
+                                                    subscriber.onCompleted();
+                                                }
+                                            }
+                                        })
+                                        .materialize()
+                                        .filter(new Func1<Notification<T>, Boolean>() {
+                                            @Override
+                                            public Boolean call(Notification<T> notification) {
+                                                return !notification.isOnCompleted();
+                                            }
+                                        }),
+                                new Func2<View, Notification<T>, Delivery<View, T>>() {
+                                    @Override
+                                    public Delivery<View, T> call(View view, Notification<T> notification) {
+                                        return view == null ? null : new Delivery<>(view, notification);
+                                    }
+                                }
+                        )
+                        .filter(new Func1<Delivery<View, T>, Boolean>() {
+                            @Override
+                            public Boolean call(Delivery<View, T> delivery) {
+                                return delivery != null;
+                            }
+                        })
+                        .subscribe(subscriber);
+
+                subscriber.add(subscription);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Hi.

**DeliverLatest** completes automatically when the source observable is done.

In my case I'm have a **Repository** which emits data from **Cache**, **DB** and **API**. I can emit from Cache first, then from DB and API. It's a sequence of distinct items.

**Why I'm not using deliveryLatestCache?** 
- to avoid keeping subscription to viewObservable
- to avoid getting the last cache from observable, cause it can be incorrect (old)

**Why I'm not using deliveryFirst?** 
- it will emit only first item (from Cache)

**Why I'm not using deliveryReplay?** 
- the item sequence in ReplaySubject might be outdated and I want just to get the new sequence from Repository (it's already got own cache)